### PR TITLE
Merge webhook url with ?wait=true

### DIFF
--- a/discord-commits/index.mjs
+++ b/discord-commits/index.mjs
@@ -40,7 +40,9 @@ const payload = {
 }
 
 try {
-  await fetch(`${webhook}?wait=true`, {
+  const webhookURL = new URL(webhook);
+  webhookURL.searchParams.set('wait','true');
+  await fetch(webhookURL.toString(), {
     method: 'POST',
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
I want to post notifications to a thread, so I need to provide the url with ?thread_id=123, but original code would make it ?thread_id=123?wait=true

so use built in url parsing library to merge the params

tested via node repl/cli
```
> a = new URL('https://www.fool.com?thread_id=1'); a.searchParams.set('wait','true'); a.toString()
'https://www.fool.com/?thread_id=1&wait=true'
```