### PR TITLE
Define newer inputs (regex, footer)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,14 @@ inputs:
     description: "The name of of a premade template."
   last-commit-only:
     description: "Boolean - only show the last commit."
+  include-commits:
+    description: "Multiline regex patterns - only include commits matching these patterns."
+  exclude-commits:
+    description: "Multiline regex patterns - exclude commits matching these patterns."
+  include-footer:
+    description: "Boolean - Include footer content in descriptions."
+  note-keywords:
+    description: "Multiline list of footer identifiers (e.g., Signed-off-by, Co-authored-by)."
 
 runs:
   using: node16


### PR DESCRIPTION
The README documents `include-commits`, `exclude-commits`, `include-footer`, and `note-keywords`  inputs, and the code in `discord-commits/index.js` implements them, but they're missing from  `action.yml`. This causes IDE schema validation warnings for users.

This PR adds the missing input definitions to match the documented and implemented functionality.